### PR TITLE
Feature persisted table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New persisted table component, a paginated table that tracks table state by query string
+
 ## [0.3.0] - 2019-07-11
 
 ### Changed

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -10,7 +10,6 @@ const INITIAL_ELEMENTS_PER_PAGE = 15
 type Props<TItem, TSchema extends JSONSchema6Type> = {
   total: number
   updatePaginationKey?: string
-  onSortChange?: (sortedBy: string, sortOrder: string) => void
   defaultElementsPerPage?: number
   defaultSortOrder?: string
   defaultSortedBy?: string
@@ -116,10 +115,9 @@ const PersistedPaginatedTable = <
     items = [],
     total,
     updatePaginationKey,
-    onSortChange = () => { },
     defaultSortOrder = 'ASC',
     defaultElementsPerPage = INITIAL_ELEMENTS_PER_PAGE,
-    defaultSortedBy='',
+    defaultSortedBy = '',
     ...tableProps
   } = props
 
@@ -185,7 +183,6 @@ const PersistedPaginatedTable = <
         sortedBy: string
       }) => {
         setQuery({ sortOrder: newSortOrder, sortedBy: newSortedBy })
-        onSortChange(newSortedBy, newSortOrder)
       }}
       {...tableProps}
     />

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { Table } from 'vtex.styleguide'
+import { JSONSchema6Type } from 'json-schema'
+import { defineMessages, FormattedMessage } from 'react-intl'
+
+import { useRuntime } from 'vtex.render-runtime'
+
+const INITIAL_ELEMENTS_PER_PAGE = 15
+
+type Props<TItem, TSchema extends JSONSchema6Type> = {
+  total: number
+  updatePaginationKey?: string
+  onSortChange?: (sortedBy: string, sortOrder: string) => void
+  defaultElementsPerPage?: number
+  defaultSortOrder?: string
+} & TableProps<TItem, TSchema>
+
+type TableProps<TItem, TSchema extends JSONSchema6Type> = {
+  items: TItem[]
+  schema: TSchema
+  loading?: boolean
+  emptyStateLabel?: React.ReactNode
+  emptyStateChildren?: React.ReactNode
+  onRowClick?: OnRowClickHandler<TItem>
+  totalizers?: any
+  filters?: any
+  toolbar?: {
+    inputSearch?: {
+      value: IntlMessage
+      placeholder: React.ReactNode
+      onChange: React.ChangeEventHandler<HTMLInputElement>
+      onClear: React.ChangeEventHandler<HTMLInputElement>
+      onSubmit: React.MouseEventHandler<HTMLSpanElement>
+    }
+    density?: {
+      buttonLabel: IntlMessage
+      lowOptionLabel: IntlMessage
+      mediumOptionLabel: IntlMessage
+      highOptionLabel: IntlMessage
+    }
+    fields?: {
+      label: IntlMessage
+      showAllLabel: IntlMessage
+      hideAllLabel: IntlMessage
+    }
+    download?: {
+      label: IntlMessage
+      handleCallback: () => void
+    }
+    upload?: {
+      label: IntlMessage
+      handleCallback: () => void
+    }
+    extraActions?: {
+      label: IntlMessage
+      actions: {
+        label: IntlMessage
+        handleCallback: () => void
+      }[]
+    }
+    newLine?: {
+      label: IntlMessage
+      handleCallback: () => void
+    }
+  }
+  lineActions?: {
+    label: () => IntlMessage
+    isDangerous?: boolean
+    onClick: Function
+  }[]
+  bulkActions?: {
+    texts: {
+      secondaryActionsLabel: string
+      rowsSelected: Function
+      selectAll: string
+      allRowsSelected: Function
+    }
+    totalItems?: number
+    main: {
+      label: string
+      handleCallback: Function
+    }
+    others: {
+      label: string
+      handleCallback: Function
+    }[]
+  }
+}
+
+export type OnRowClickHandler<TItem> = ({ rowData }: { rowData: TItem }) => void
+export type IntlMessage = string | JSX.Element
+
+const messages = defineMessages({
+  of: {
+    id: 'admin/channels.table.of',
+    defaultMessage: 'of',
+  },
+  showRowsLabel: {
+    id: 'admin/channels.table.show-rows',
+    defaultMessage: 'Show rows',
+  },
+})
+
+const PersistedPaginatedTable = <
+  TItem,
+  TSchema extends JSONSchema6Type
+>(
+  props: Props<TItem, TSchema>
+) => {
+  const [sortedBy, setSortedBy] = useState('')
+  const didMountRef = useRef(false)
+
+  const { setQuery, query } = useRuntime()
+
+  const {
+    items = [],
+    total,
+    updatePaginationKey,
+    onSortChange = () => { },
+    defaultSortOrder = 'ASC',
+    defaultElementsPerPage = INITIAL_ELEMENTS_PER_PAGE,
+    ...tableProps
+  } = props
+
+  useEffect(() => {
+    if (didMountRef.current) {
+      setQuery({ to: defaultElementsPerPage, from: 0, elements: defaultElementsPerPage })
+    } else {
+      didMountRef.current = true
+    }
+  }, [updatePaginationKey])
+
+  const onPageChange = (
+    currentFrom: number,
+    currentElementsPerPage: number,
+    direction: string
+  ) => async () => {
+    const c = direction === 'next' ? 1 : -1
+
+    const newFrom = currentFrom + c * currentElementsPerPage
+
+    const newTo = Math.min(newFrom + currentElementsPerPage, total)
+
+    setQuery({ to: newTo, from: newFrom, elements: currentElementsPerPage })
+  }
+
+  const elementsPerPage = parseInt(query.elements) || defaultElementsPerPage
+  const from = parseInt(query.from) || 0
+  const to = parseInt(query.to) || elementsPerPage
+  const sortOrder = query.sortOrder || defaultSortOrder
+
+  return (
+    <Table
+      fullWidth
+      items={items}
+      pagination={{
+        currentItemFrom: from + 1,
+        currentItemTo: to,
+        onNextClick: onPageChange(from, elementsPerPage, 'next'),
+        onPrevClick: onPageChange(from, elementsPerPage, 'prev'),
+        rowsOptions: [5, 10, 15, 25],
+        selectedOption: elementsPerPage,
+        onRowsChange: async (e: React.ChangeEvent<HTMLSelectElement>) => {
+          const newElementsPerPage = parseInt(e.target.value)
+          const currentPage = Math.floor(from / newElementsPerPage)
+          const newFrom = currentPage * newElementsPerPage
+          setQuery({ elements: newElementsPerPage, from: newFrom, to: newFrom + newElementsPerPage })
+        },
+        textOf: <FormattedMessage {...messages.of} />,
+        textShowRows: <FormattedMessage {...messages.showRowsLabel} />,
+        totalItems: total,
+      }}
+      density="low"
+      sort={{
+        sortedBy,
+        sortOrder,
+      }}
+      onSort={({
+        sortOrder: newSortOrder,
+        sortedBy: newSortedBy,
+      }: {
+        sortOrder: string
+        sortedBy: string
+      }) => {
+        setQuery({ sortOrder: newSortOrder })
+        setSortedBy(newSortedBy)
+        onSortChange(newSortedBy, newSortOrder)
+      }}
+      {...tableProps}
+    />
+  )
+}
+
+export default PersistedPaginatedTable

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Table } from 'vtex.styleguide'
 import { JSONSchema6Type } from 'json-schema'
 import { defineMessages, FormattedMessage } from 'react-intl'
@@ -13,6 +13,7 @@ type Props<TItem, TSchema extends JSONSchema6Type> = {
   onSortChange?: (sortedBy: string, sortOrder: string) => void
   defaultElementsPerPage?: number
   defaultSortOrder?: string
+  defaultSortedBy?: string
 } & TableProps<TItem, TSchema>
 
 type TableProps<TItem, TSchema extends JSONSchema6Type> = {
@@ -107,7 +108,6 @@ const PersistedPaginatedTable = <
 >(
   props: Props<TItem, TSchema>
 ) => {
-  const [sortedBy, setSortedBy] = useState('')
   const didMountRef = useRef(false)
 
   const { setQuery, query } = useRuntime()
@@ -119,6 +119,7 @@ const PersistedPaginatedTable = <
     onSortChange = () => { },
     defaultSortOrder = 'ASC',
     defaultElementsPerPage = INITIAL_ELEMENTS_PER_PAGE,
+    defaultSortedBy='',
     ...tableProps
   } = props
 
@@ -148,6 +149,7 @@ const PersistedPaginatedTable = <
   const from = parseInt(query.from) || 0
   const to = parseInt(query.to) || elementsPerPage
   const sortOrder = query.sortOrder || defaultSortOrder
+  const sortedBy = query.sortedBy || defaultSortedBy
 
   return (
     <Table
@@ -182,8 +184,7 @@ const PersistedPaginatedTable = <
         sortOrder: string
         sortedBy: string
       }) => {
-        setQuery({ sortOrder: newSortOrder })
-        setSortedBy(newSortedBy)
+        setQuery({ sortOrder: newSortOrder, sortedBy: newSortedBy })
         onSortChange(newSortedBy, newSortOrder)
       }}
       {...tableProps}

--- a/react/package.json
+++ b/react/package.json
@@ -10,7 +10,7 @@
     "@types/jest": "^24.0.11",
     "@types/json-schema": "^7.0.3",
     "@types/node": "^10.12.17",
-    "@types/react": "^16.7.17",
+    "@types/react": "^16.8.23",
     "@vtex/test-tools": "^0.1.4",
     "prettier": "^1.16.4",
     "tslint": "^5.12.0",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -846,9 +846,9 @@
   version "2.3.17"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.17.tgz#e1fc6e46e8af58bdef9531259d509380a8a99e8e"
 
-"@types/react@^16.7.17":
-  version "16.7.17"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.17.tgz#3242e796a1ffbba4f49eae5915a67f4c079504e9"
+"@types/react@^16.8.23":
+  version "16.8.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
This PR adds a new component `Persisted Paginated Table` to be used by Channels and Suggestions admin.

This new component was motivated by the need our clients have to be able to preserve the table state on reload