### PR TITLE
Maintain table page size on row sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Sorting table bug that caused the page size to change to default
+
 ## [0.5.1] - 2019-09-03
+
+### Added
+
+- Documentation builder
 
 ## [0.5.0] - 2019-08-14
 

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -101,10 +101,7 @@ const messages = defineMessages({
   },
 })
 
-const PersistedPaginatedTable = <
-  TItem,
-  TSchema extends JSONSchema6Type
->(
+const PersistedPaginatedTable = <TItem, TSchema extends JSONSchema6Type>(
   props: Props<TItem, TSchema>
 ) => {
   const didMountRef = useRef(false)
@@ -121,9 +118,11 @@ const PersistedPaginatedTable = <
     ...tableProps
   } = props
 
+  const elementsPerPage = parseInt(query.elements) || defaultElementsPerPage
+
   useEffect(() => {
     if (didMountRef.current) {
-      setQuery({ to: defaultElementsPerPage, from: 0, elements: defaultElementsPerPage })
+      setQuery({ to: elementsPerPage, from: 0, elements: elementsPerPage })
     } else {
       didMountRef.current = true
     }
@@ -143,7 +142,6 @@ const PersistedPaginatedTable = <
     setQuery({ to: newTo, from: newFrom, elements: currentElementsPerPage })
   }
 
-  const elementsPerPage = parseInt(query.elements) || defaultElementsPerPage
   const from = parseInt(query.from) || 0
   const to = parseInt(query.to) || elementsPerPage
   const sortOrder = query.sortOrder || defaultSortOrder
@@ -164,7 +162,11 @@ const PersistedPaginatedTable = <
           const newElementsPerPage = parseInt(e.target.value)
           const currentPage = Math.floor(from / newElementsPerPage)
           const newFrom = currentPage * newElementsPerPage
-          setQuery({ elements: newElementsPerPage, from: newFrom, to: newFrom + newElementsPerPage })
+          setQuery({
+            elements: newElementsPerPage,
+            from: newFrom,
+            to: newFrom + newElementsPerPage,
+          })
         },
         textOf: <FormattedMessage {...messages.of} />,
         textShowRows: <FormattedMessage {...messages.showRowsLabel} />,


### PR DESCRIPTION
Effect applied on `updatePaginationKey` was resetting the table entirely, save for the sort order. Instead, the effect should at least maintain the page size.

Testable in [this link](https://artur--sandboxintegracao.myvtex.com/admin/suggestion/approved?elements=25&from=0&sortOrder=DESC&sortedBy=price&to=25)