### PR TITLE
Use default sort order as preferential sort order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default sort order is now used as the persisted table preferred sort order
+
 ## [0.5.3] - 2019-09-06
 
 ### Changed

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -174,8 +174,9 @@ const PersistedPaginatedTable = <TItem, TSchema extends JSONSchema6Type>(
       }}
       density="low"
       sort={{
-        sortedBy,
+        preferentialSortOrder: defaultSortOrder,
         sortOrder,
+        sortedBy,
       }}
       onSort={({
         sortOrder: newSortOrder,


### PR DESCRIPTION
The default sort order can now be used in the styleguide's table as the
preferential sort order

You can test this in [this link](https://artur--sandboxintegracao.myvtex.com/admin/received-skus/approved). Click on any of the `price`/`stock` columns, the default `DESC` order passed down by the linked admin-suggestions is now used as the first sort order