### PR TITLE
Add dynamic row height option to persisted table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dynamic row height option to persisted table API
+
 ## [0.5.4] - 2019-09-25
 
 ### Changed

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -21,6 +21,7 @@ type TableProps<TItem, TSchema extends JSONSchema6Type> = {
   loading?: boolean
   emptyStateLabel?: React.ReactNode
   emptyStateChildren?: React.ReactNode
+  dynamicRowHeight?: boolean
   onRowClick?: OnRowClickHandler<TItem>
   totalizers?: any
   filters?: any


### PR DESCRIPTION
Styleguide's table has recently implemented a dynamic row height functionality. This change documents the possible usage of the feature.

[Link](https://artur--sandboxintegracao.myvtex.com/admin/received-skus/approved/) with a functioning table