### PR TITLE
Fix table not redirecting after last page emptying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Redirect to first page when user is in page that beyond the total of items
+
 ### Added
 
 - Dynamic row height option to persisted table API

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -129,6 +129,12 @@ const PersistedPaginatedTable = <TItem, TSchema extends JSONSchema6Type>(
     }
   }, [updatePaginationKey])
 
+  useEffect(() => {
+    if (total < query.to) {
+      setQuery({ to: elementsPerPage, from: 0, elements: elementsPerPage })
+    }
+  }, [total])
+
   const onPageChange = (
     currentFrom: number,
     currentElementsPerPage: number,

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -130,7 +130,7 @@ const PersistedPaginatedTable = <TItem, TSchema extends JSONSchema6Type>(
   }, [updatePaginationKey])
 
   useEffect(() => {
-    if (total < query.to) {
+    if (total && total < query.to) {
       setQuery({ to: elementsPerPage, from: 0, elements: elementsPerPage })
     }
   }, [total])


### PR DESCRIPTION
When some user tried to visit a page beyond the total of items the table would just display "no items" available. Now the table redirects to the first page, so when some user empties the last page of the table they are redirected back to the first page. Instead of hanging around in an empty page.

Working example in https://anita--partnerchallenge26.myvtex.com/admin/received-skus/pending/?elements=25&from=0&to=25