### PR TITLE
Add usage of `hasPageTopIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support of Styleguide's Table `hasPageTopIndicator` prop.
+
 ## [0.5.7] - 2019-11-21
 
 ### Added

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,5 @@
 {
   "admin/table.show-rows": "Mostrar filas",
-  "admin/table.of": "de"
+  "admin/table.of": "de",
+  "admin/table.item-label": "{total, plural, one {artículo} other {artículos}}"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,5 @@
 {
   "admin/table.show-rows": "Mostrar linhas",
-  "admin/table.of": "de"
+  "admin/table.of": "de",
+  "admin/table.item-label": "{total, plural, one {item} other {itens}}"
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support to the `hasPageTopIndicator` pagination flag.

#### What problem is this solving?

Recently a `hasPageTopIndicator` flag has been added to the `Pagination` component in Styleguide. In order to add support to this feature, pass down this flag to the `Table` component in `PersistedPaginatedTable`. This should follow the deploy of https://github.com/vtex/styleguide/pull/950

#### How should this be manually tested?

You may visit [this workspace](https://artur--partnerchallenge26.myvtex.com/admin/received-skus/approved/) and check a `PersistedPaginatedTable` with the table pagination top indicator

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/69645078-5a7a3380-1044-11ea-8cc3-40c66d726d66.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
