### PR TITLE
Update PersistedPaginatedTable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `PersistedPaginatedTable` types
+
 ## [0.6.0] - 2019-12-02
 
 ### Added

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -19,6 +19,8 @@ interface TableProps<TItem, TSchema extends JSONSchema6Type> {
   items: TItem[]
   schema: TSchema
   loading?: boolean
+  fullWidth?: boolean
+  density?: 'low' | 'medium' | 'high'
   emptyStateLabel?: React.ReactNode
   emptyStateChildren?: React.ReactNode
   dynamicRowHeight?: boolean
@@ -32,7 +34,7 @@ interface TableProps<TItem, TSchema extends JSONSchema6Type> {
       placeholder: React.ReactNode
       onChange: React.ChangeEventHandler<HTMLInputElement>
       onClear: React.ChangeEventHandler<HTMLInputElement>
-      onSubmit: React.MouseEventHandler<HTMLSpanElement>
+      onSubmit: React.FormEventHandler<HTMLFormElement>
     }
     density?: {
       buttonLabel: IntlMessage

--- a/react/package.json
+++ b/react/package.json
@@ -15,7 +15,7 @@
     "prettier": "^1.16.4",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3986,10 +3986,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.3.3333"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update `PersistedPaginatedTable` types to contain missing Table props

#### What problem is this solving?

This enables dependants to use `fullWidth` and `density` properties

#### How should this be manually tested?
You can visit [this link](https://test--sandboxintegracao.myvtex.com/admin/sellers) all should be functioning normally

#### Screenshots or example usage
None

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
