### PR TITLE
Fix type of pagination prop of PersistedPaginatedTable component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prop `pagination` type of `PersistedPaginatedTable`, it should be optional since it has a default value.
+
 ## [0.7.2] - 2020-03-12
 
 ## [0.7.1] - 2019-12-23

--- a/react/PersistedPaginatedTable.tsx
+++ b/react/PersistedPaginatedTable.tsx
@@ -89,7 +89,7 @@ interface TableProps<TItem, TSchema extends JSONSchema6Type> {
       handleCallback: (params: { selectedRows: TItem[] }) => void
     }>
   }
-  pagination: {
+  pagination?: {
     hasPageTopIndicator: boolean
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

The generated types from toolbelt are wrong because the `pagination` prop is optional, but in the types of `Prop` isn't.

#### How should this be manually tested?

This is just a typing error, shouldn't  break anyone

#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
