### PR TITLE
Trigger mouse leave when leaving table body area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Trigger onMouseLeave event when moving mouse from table body area to table header area
+
 ## [0.10.0] - 2020-06-23
 
 ### Changed

--- a/react/ExtendedTable.tsx
+++ b/react/ExtendedTable.tsx
@@ -144,40 +144,38 @@ const CustomTable = (props: TableProps) => {
   const { onMouseEnter = () => {}, onMouseLeave = () => {} } = hovering || {}
   const { sorting } = tableProps
   return (
-    <div onMouseLeave={onMouseLeave}>
-      <Table composableSections {...tableProps}>
-        {children}
-        <Table.Sections>
-          {
-            !sorting ? 
-              <HeadWithoutUpperLine />
-            : (
-              <HeadWithDefaultSorting sorting={sorting} />
+    <Table composableSections {...tableProps}>
+      {children}
+      <Table.Sections>
+        {
+          !sorting ? 
+            <HeadWithoutUpperLine />
+          : (
+            <HeadWithDefaultSorting sorting={sorting} />
+          )
+        }
+        <Table.Sections.Body ref={measuringRef} onMouseLeave={onMouseLeave}>
+          {({ key, props: rowProps }: { key: string; props: any }) => {
+            return !rowProps.data.isExpandable || !props.rowExpansion?.isRowExpandedMap ? (
+              <Table.Sections.Body.Row
+                key={key}
+                onMouseEnter={() => onMouseEnter(rowProps.data.id)}
+                {...rowProps}
+              />
+            ) : (
+              <CollapsableRow
+                key={key}
+                onMouseEnter={() => onMouseEnter(rowProps.data.id)}
+                onRowClick={tableProps.onRowClick}
+                columns={props.columns}
+                isExpanded ={props.rowExpansion?.isRowExpandedMap[rowProps.data.id]}
+                {...rowProps}
+              />
             )
-          }
-          <Table.Sections.Body ref={measuringRef}>
-            {({ key, props: rowProps }: { key: string; props: any }) => {
-              return !rowProps.data.isExpandable || !props.rowExpansion?.isRowExpandedMap ? (
-                <Table.Sections.Body.Row
-                  key={key}
-                  onMouseEnter={() => onMouseEnter(rowProps.data.id)}
-                  {...rowProps}
-                />
-              ) : (
-                <CollapsableRow
-                  key={key}
-                  onMouseEnter={() => onMouseEnter(rowProps.data.id)}
-                  onRowClick={tableProps.onRowClick}
-                  columns={props.columns}
-                  isExpanded ={props.rowExpansion?.isRowExpandedMap[rowProps.data.id]}
-                  {...rowProps}
-                />
-              )
-            }}
-          </Table.Sections.Body>
-        </Table.Sections>
-      </Table>
-    </div>
+          }}
+        </Table.Sections.Body>
+      </Table.Sections>
+    </Table>
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Trigger mouse leave when leaving table rows area.

#### What problem is this solving?

The rows hover effect was not turning off after leaving rows area, only when leaving whole table area (table header + table rows).

#### How should this be manually tested?

[Workspace](https://gabriela--sandboxintegracao.myvtex.com/admin/app/received-skus/pending)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
