### PR TITLE
Fix measure for row height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix measure for row height
+
 ## [0.10.2] - 2020-08-06
 
 ### Added

--- a/react/useDynamicMeasures.tsx
+++ b/react/useDynamicMeasures.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useLayoutEffect } from 'react'
+import { useCallback, useLayoutEffect, useState } from 'react'
 
 const getHeight = (node: HTMLElement) => {
   const rect = node.getBoundingClientRect()
@@ -15,7 +15,7 @@ export function calculateTableHeight(
   tableSize: number,
   headless?: boolean
 ): number {
-  const multiplicator = tableSize !== 0 ? tableSize * rowHeight : EMPTY_STATE_SIZE
+  const multiplicator = Boolean(tableSize) ? tableSize * rowHeight : EMPTY_STATE_SIZE
   return (headless ? 0 : TABLE_HEADER_HEIGHT) + multiplicator
 }
 
@@ -51,8 +51,8 @@ const useDynamicMeasures = ({ lenght, headless }: { lenght: number; headless?: b
   }, [node])
 
   return {
+    measures: { tableHeight, rowHeight: 'auto' },
     ref,
-    measures: { tableHeight },
     triggerResize: node ? () => measure(node) : () => {},
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Some tables look "shrinked" on Firefox. See https://connectparts.myvtex.com/admin/sent-offers/4b176c8f83754345a718987a8fa549bb/offer/2016210/logs/.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Firefox can't handle table columns with `height: 0`, so we must not ignore the `rowHeight` prop on the new table. Actually the styleguide itself could set the default value to `auto`, but this fix is enough, easier and quick.

#### How should this be manually tested?
https://augusto--connectparts.myvtex.com/admin/sent-offers/4b176c8f83754345a718987a8fa549bb/offer/2016210/logs/

#### Screenshots or example usage
![Kapture 2020-09-02 at 16 22 01](https://user-images.githubusercontent.com/7659279/92027128-8398c480-ed38-11ea-88fe-f88ac7bf33d6.gif)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
