### PR TITLE
Remove pseudo language and fix Spanish, Italian, Japanese and Thai translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Spanish, Italian, Japanese and Thai translations.
+
+### Removed
+- Pseudo language.
+
 ## [0.13.1] - 2022-07-13
 
 ### Added

--- a/messages/bs-BA.json
+++ b/messages/bs-BA.json
@@ -1,5 +1,0 @@
-{
-  "admin/table.show-rows": "crwdns124682:0crwdne124682:0",
-  "admin/table.of": "crwdns124684:0crwdne124684:0",
-  "admin/table.item-label": "crwdns124686:0total={total}crwdne124686:0"
-}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,5 @@
 {
   "admin/table.show-rows": "Mostrar filas",
   "admin/table.of": "de",
-  "admin/table.item-label": "{total, plural, one {artículo} other {artículos}}"
+  "admin/table.item-label": "{total, plural, one {ítem} other {ítems}}"
 }

--- a/messages/it-IT.json
+++ b/messages/it-IT.json
@@ -1,5 +1,5 @@
 {
   "admin/table.show-rows": "Mostra righe",
   "admin/table.of": "di",
-  "admin/table.item-label": "{total, plural, one {articolo} other {articoli}}"
+  "admin/table.item-label": "{total, plural, one {elemento} other {elementi}}"
 }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -1,5 +1,5 @@
 {
-  "admin/table.show-rows": "行を表示する",
-  "admin/table.of": "の",
+  "admin/table.show-rows": "表示行数",
+  "admin/table.of": "/",
   "admin/table.item-label": "{total, plural, one {項目} other {項目}}"
 }

--- a/messages/th-TH.json
+++ b/messages/th-TH.json
@@ -1,5 +1,5 @@
 {
   "admin/table.show-rows": "แสดงแถว",
   "admin/table.of": "ของ",
-  "admin/table.item-label": "{total, plural, one {แถว} other {แถว}}"
+  "admin/table.item-label": "{total, plural, one {รายการ} other {รายการ}}"
 }


### PR DESCRIPTION
Remove pseudo language and fix Spanish, Italian, Japanese, and Thai translations. It relates to [LOC-9171](https://vtex-dev.atlassian.net/browse/LOC-9171) and the current admin review that the localization team is doing.